### PR TITLE
Data augmentations and bug fixes

### DIFF
--- a/dqn/DQN.py
+++ b/dqn/DQN.py
@@ -2,6 +2,7 @@ import torch.nn.functional as F
 import torch.nn as nn
 import numpy as np
 import torch
+import torchvision.transforms as transforms
 import copy
 from rl.rl_utils import *
 
@@ -12,6 +13,25 @@ def build_net(layer_shape, activation, output_activation):
 		act = activation if j < len(layer_shape)-2 else output_activation
 		layers += [nn.Linear(layer_shape[j], layer_shape[j+1]), act()]
 	return nn.Sequential(*layers)
+
+def gauss_noise_tensor(sigma_range):
+    def gauss_noise_tensor_f(img, sigma_range):
+        assert isinstance(img, torch.Tensor)
+        dtype = img.dtype
+        if not img.is_floating_point():
+            img = img.to(torch.float32)
+
+        if sigma_range[0] == sigma_range[1]:
+            sigma = sigma_range[0]
+        else:
+            sigma = torch.rand(1) * (sigma_range[1] - sigma_range[0]) + sigma_range[0]
+        out = img + sigma * torch.randn_like(img)
+
+        if out.dtype != dtype:
+            out = out.to(dtype)
+
+        return out
+    return lambda img: gauss_noise_tensor_f(img, sigma_range)
 
 class ActorTimestepNet(nn.Module):
     def __init__(self, block, layers, num_classes = 10):
@@ -212,6 +232,24 @@ class ReplayBuffer(object):
 			self.s_next = torch.zeros((max_size, state_dim),dtype=torch.float,device=self.train_device)
 		self.dw = torch.zeros((max_size, 1),dtype=torch.bool,device=self.train_device)
 		self.data_augmentation = data_augmentation
+		self.augmentation = transforms.Compose([
+			# Rotation
+			transforms.Pad((150, 210), padding_mode='edge'),
+			transforms.RandomRotation(10, transforms.InterpolationMode.NEAREST),
+			transforms.CenterCrop((180, 260)),
+			
+			# Random Crop
+			transforms.RandomCrop((180, 260), padding=(15, 21), padding_mode='edge'),
+			
+			# Random Resized Crop
+			transforms.RandomResizedCrop((180, 260), scale=(0.9, 1.0)),
+			
+			# Gaussian Blur
+			transforms.GaussianBlur((21, 21), sigma=(0.1, 2.0)),
+			
+			# Salt and Pepper
+			gauss_noise_tensor((0, 0.05)),
+		])
 
 	def add(self, s, a, r, s_next, dw):
 		# self.s[self.ptr] = s.to(self.train_device)
@@ -228,14 +266,18 @@ class ReplayBuffer(object):
 			self.ptr = (self.ptr + 1) % self.max_size
 			self.size = min(self.size + 1, self.max_size)
 
-		self.ptr = (self.ptr + 1) % self.max_size
-		self.size = min(self.size + 1, self.max_size)
-
 	def sample(self, batch_size):
 		ind = torch.randint(0, self.size, device=self.train_device, size=(batch_size,))
+		s = self.s[ind]
+		s_next = self.s_next[ind]
 		if self.data_augmentation:
-			self.s[ind] = data_augmentation(self.s[ind])
-		return self.s[ind], self.a[ind], self.r[ind], self.s_next[ind], self.dw[ind]
+			# TODO(Henri): process idxs of seg mask
+			s_s_next = torch.cat((s, s_next), axis=0)
+			assert s_s_next.shape == (s.shape[0]*2, 3, 180, 260)
+			s_s_next = self.augmentation(s_s_next)
+			s, s_next = s_s_next[:s.shape[0]], s_s_next[s.shape[0]:]
+			
+		return s, self.a[ind], self.r[ind], s_next, self.dw[ind]
 
 
 

--- a/dqn/main.py
+++ b/dqn/main.py
@@ -36,7 +36,7 @@ parser.add_argument('--ModelName', type=str, default='DDQN_2023-12-06_03-56-03',
 parser.add_argument('--ModelIdex', type=int, default=250*1000, help='which model to load')
 
 parser.add_argument('--seed', type=int, default=0, help='random seed')
-parser.add_argument('--data_augmentation', type=str2bool, default=False, help='data augmentation')
+parser.add_argument('--data_augmentation_prob', type=float, default=0., help='data augmentation')
 parser.add_argument('--Max_train_steps', type=int, default=int(1e6), help='Max training steps')
 parser.add_argument('--save_interval', type=int, default=int(10), help='Model saving interval, in steps.')
 parser.add_argument('--eval_interval', type=int, default=int(10), help='Model evaluating interval, in steps.')


### PR DESCRIPTION
- Added in data augmentations. 
- Changed `data_augmentation` flag to `data_augmentation_prob`
- Also fixed small replay buffer bug on line 231.

@kaikwan I didn't process idxs of seg mask. I'll leave to that you. Look for `TODO(Henri)`

Command I used for testing: `python main.py --EnvIdex 1 --render True --DDQN True --write True --random_steps 0 --update_every 10 --save_interval 10 --eval_interval 10 --num_envs 10 --res_net True --batch_size 10 --buffer_size 1e2 --lr 1e-6 --data_augmentation_prob 0.95`

Sample augmented images:
![image](https://github.com/bolingy/grasp-point-selection-sim/assets/3770940/d0deaa02-2ce8-42c4-a10c-932ff9e9ffa8)
![image](https://github.com/bolingy/grasp-point-selection-sim/assets/3770940/8e8f05f0-7518-4ddc-b73e-1446fb6b739e)